### PR TITLE
Fix deb versions again

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - name: Get version
         id: version
-        run: echo "version=$(git describe)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(git describe --tags)" >> "$GITHUB_OUTPUT"
       - name: Set up Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
This works around a bug in actions/checkout that creates lightweight tags of the same name instead of actually fetching the annotated tag from the repo.